### PR TITLE
Add Plugins with multiple configurations and Tool plugin

### DIFF
--- a/scripts/generate_plugin_index.js
+++ b/scripts/generate_plugin_index.js
@@ -134,7 +134,8 @@ const indexScript = async function generateIndexScript(plugin) {
         version,
         description,
         type: edtrio.type,
-        options: edtrio.options
+        options: edtrio.options,
+        multi: edtrio.multi,
     };
 
     const { base } = path.parse(plugin);

--- a/src/UI/PluginPreview/PluginPreview.jsx
+++ b/src/UI/PluginPreview/PluginPreview.jsx
@@ -6,12 +6,12 @@ import styles from './styles.scss';
 
 class PluginPreview extends Component {
     render() {
-        const { name, description, image } = this.props;
+        const { name, displayName, description, image } = this.props;
 
         return (
             <figure className={styles.imageWrapper}>
                 <img src={image} className={styles.previewImage}/>
-                <figcaption className={styles.title}>{name}</figcaption>
+                <figcaption className={styles.title}>{displayName || name}</figcaption>
             </figure>
         )
     }
@@ -19,6 +19,7 @@ class PluginPreview extends Component {
 
 PluginPreview.propTypes = {
     name: PropTypes.string,
+    displayName: PropTypes.string,
     description: PropTypes.string,
     image: PropTypes.any.isRequired,
 }

--- a/src/UI/PluginPreview/PluginPreview.jsx
+++ b/src/UI/PluginPreview/PluginPreview.jsx
@@ -18,7 +18,7 @@ class PluginPreview extends Component {
 }
 
 PluginPreview.propTypes = {
-    name: PropTypes.string,
+    name: PropTypes.string.isRequired,
     displayName: PropTypes.string,
     description: PropTypes.string,
     image: PropTypes.any.isRequired,

--- a/src/editor/components/AddPlugin/AddPlugin.jsx
+++ b/src/editor/components/AddPlugin/AddPlugin.jsx
@@ -28,9 +28,38 @@ class AddPlugin extends PureComponent {
     }
 
     render() {
-        const content = [];
-        const layout = [];
-        const input = [];
+      const content = [];
+      const layout = [];
+      const input = [];
+
+      const pushPlugin = info => {
+        const temp = (
+          <div key={info.name} className={styles.item}>
+            <MenuItem
+              key={info.name}
+              onClick={e => {
+                this.handleClose();
+                this.props.addPlugin(info);
+              }}
+            >
+              <PluginPreview
+                name={info.name}
+                displayName={info.displayName}
+                image={info.preview_image}
+                description={info.description}
+              />
+            </MenuItem>
+          </div>
+        );
+
+        if (info.type === "CONTENT") {
+          content.push(temp);
+        } else if (info.type === "INPUT") {
+          input.push(temp);
+        } else {
+          layout.push(temp);
+        }
+      }
 
         return (
             <React.Fragment>
@@ -40,30 +69,14 @@ class AddPlugin extends PureComponent {
                 >
                     <React.Fragment>
                         {PluginResolver.allPlugins.map(info => {
-                            const temp = (
-                                <div key={info.name} className={styles.item}>
-                                    <MenuItem
-                                        key={info.name}
-                                        onClick={e => {
-                                            this.handleClose();
-                                            this.props.addPlugin(info);
-                                        }}
-                                    >
-                                        <PluginPreview
-                                            name={info.name}
-                                            image={info.preview_image}
-                                            description={info.description}
-                                        />
-                                    </MenuItem>
-                                </div>
-                            );
-
-                            if (info.type === "CONTENT") {
-                                content.push(temp);
-                            } else if (info.type === "INPUT") {
-                                input.push(temp);
+                            if(info.multi) {
+                              info.multi.map(plugin => {
+                                plugin.preview_image = info.preview_image;
+                                plugin.name = info.name;
+                                pushPlugin(plugin)
+                              });
                             } else {
-                                layout.push(temp);
+                              pushPlugin(info);
                             }
                         })}
 

--- a/src/editor/components/Editor/index.js
+++ b/src/editor/components/Editor/index.js
@@ -79,14 +79,14 @@ class Editor extends Component {
                                     plugin={plugin.name}
                                     key={plugin.id}
                                 >
-                                    {Module => <Module id={plugin.id} />}
+                                    {Module => <Module id={plugin.id} {...plugin.options} />}
                                 </PluginResolver>
                             )
                         );
                     })}
                 </div>
 
-                <AddPlugin addPlugin={name => this._addPlugin(name)} />
+                <AddPlugin addPlugin={configuration => this._addPlugin(configuration)} />
             </React.Fragment>
         );
     }

--- a/src/editor/components/PluginWrapper/index.js
+++ b/src/editor/components/PluginWrapper/index.js
@@ -182,7 +182,8 @@ export default function makePlugin(WrappedComponent, info) {
                 editable,
                 saveContent,
                 isOver,
-                canDrop
+                canDrop,
+                initialState
             } = this.props;
 
             const { highlight } = this.state;
@@ -220,6 +221,7 @@ export default function makePlugin(WrappedComponent, info) {
                                         id={id}
                                         isEditable={editable}
                                         isViewMode={false}
+                                        initialState={initialState}
                                         content={plugin.content}
                                         saveContent={content =>
                                             saveContent(content)
@@ -285,7 +287,8 @@ export default function makePlugin(WrappedComponent, info) {
             id: PropTypes.number.isRequired,
             options: PropTypes.shape({
                 allowChildRearrangement: PropTypes.bool
-            })
+            }),
+            initialState: PropTypes.object
         };
 
         static defaultProps = {

--- a/src/models/Plugin.js
+++ b/src/models/Plugin.js
@@ -8,9 +8,10 @@ class Plugin {
             type = mandatory("type")
         },
         //options
-        { size, allowChildRearrangement } = {
+        { size, allowChildRearrangement, initialState } = {
             size: 0,
-            allowChildRearrangement: true
+            allowChildRearrangement: true,
+            initialState: {}
         }
     ) {
         this.id = id;
@@ -24,7 +25,8 @@ class Plugin {
         this.visible = true;
 
         this.options = {
-            allowChildRearrangement
+            allowChildRearrangement,
+            initialState
         };
     }
 

--- a/src/plugins/Tool/Tool.jsx
+++ b/src/plugins/Tool/Tool.jsx
@@ -1,0 +1,67 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import styles from "./styles.scss";
+
+
+export default class Tool extends Component {
+    constructor(props) {
+      super(props);
+
+      const { ltiBaseUrl } = document.getElementById("root").dataset;
+      this.refFrame = React.createRef();
+
+      this.state = {
+        tool: (this.props.initialState ? this.props.initialState.tool : {}),
+        ltiBaseUrl,
+      };
+    }
+
+    componentDidMount() {
+      this.setState({
+        ...this.props.content
+      });
+      this.props.saveContent({ tool: this.state.tool })
+    }
+
+    enterFullscreen() {
+      const elem = this.refFrame.current;
+      if (elem.requestFullScreen) {
+        elem.requestFullScreen();
+      } else if (elem.webkitRequestFullScreen) {
+        elem.webkitRequestFullScreen();
+      } else if (elem.mozRequestFullScreen) {
+        elem.mozRequestFullScreen();
+      }
+    }
+
+    render() {
+        const { tool, ltiBaseUrl } = this.state;
+        const { isEditable } = this.props;
+
+        let src = null;
+        if (tool.ltiId && ltiBaseUrl) {
+          src = ltiBaseUrl + tool.ltiId;
+        } else if (tool.url) {
+          src = tool.url;
+        }
+
+        return (src
+            ? (
+            <div>
+              <button className={styles.fullscreenButton} onClick={e => this.enterFullscreen()}>Vollbild</button>
+              <iframe className={styles.frame} src={src} ref={this.refFrame} />
+            </div>
+            )
+            : (
+            <p>Das Tool kann eventuell nur in der Schul-Cloud angezeigt werden.</p>
+            )
+        );
+    }
+
+    static propTypes = {
+        isEditable: PropTypes.bool.isRequired,
+        content: PropTypes.object,
+        saveContent: PropTypes.func.isRequired,
+        initialState: PropTypes.object
+    };
+}

--- a/src/plugins/Tool/package.json
+++ b/src/plugins/Tool/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "Tool",
+    "version": "0.1.0",
+    "description": "Iframe Integration von Tools",
+    "main": "Tool.jsx",
+    "author": "Dominik Glandorf",
+    "license": "MIT",
+    "edtrio": {
+        "displayName": "Tool",
+        "type": "CONTENT",
+        "multi": [
+            {
+                "displayName": "Cornelsen",
+                "type": "CONTENT",
+                "options": {
+                    "initialState": {
+                        "tool": {
+                            "ltiId": "5ab2352a4c11fb177ce9de46"
+                        }
+                    }
+                }
+            },
+            {
+                "displayName": "bettermarks",
+                "type": "CONTENT",
+                "options": {
+                    "initialState": {
+                        "tool": {
+                            "url": "https://acc.bettermarks.com/v1.0/schulcloud/login"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/plugins/Tool/styles.scss
+++ b/src/plugins/Tool/styles.scss
@@ -1,0 +1,10 @@
+.frame {
+  width: 100%;
+  height: 600px;
+}
+
+.fullscreenButton {
+  position: absolute;
+  right: 15px;
+  top: 0px;
+}


### PR DESCRIPTION
Providing the multi property in the package.json now it is possible to instantiate a plugin with different initialStates. This improves the user comfort and reduces code duplication significantly.

The tool plugin is a good example for this architecture. In any case it will display an Iframe. But now different URLs or tool ids can be configured.