### PR TITLE
Reintroduce plugins/(paste-)url-handler

### DIFF
--- a/docs/plugins/overview.mdx
+++ b/docs/plugins/overview.mdx
@@ -11,13 +11,16 @@ These are all custom developed plugins currently included in Edtr.io:
 | Plugin               | Description                                  |
 | -------------------- | -------------------------------------------- |
 | `add-section`        | Exports button component to append a section |
+| `audio`              | Adds html5 audio elements                    |
 | `code-block`         | Adds simple code blocks to the editor        |
 | `embed`              | Adds embedding capabilities to videos, iframes etc.|
 | `geogebra`           | Adds geogebra to the editor                  |
 | `headlines`          | Adds support for all headlines h1-h6         |
 | `image`              | Adds images to the editor                    |
 | `markdown-shortcuts` | Automatically turns markdown into rich elements |
+| `paste-url-handler`  | Automatically turns urls into rich elements  |
 | `plus-menu`          | Adds small plus to row to add interactive content |
 | `section`            | Adds sections and p tags to the editor       |
 | `text-menu`          | Adds popup text menu (bold, italic, ...)     |
 | `title`              | Adds a title to the editor                   |
+| `video`              | Adds html5 video elements                    |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "author": {
     "name": "Florian Wirtz",
-    "email": "florian.wirtz@student.hpi.de",
+    "email": "florian.wirtz@hpi-alumni.de",
     "url": "https://github.com/FWirtz"
   },
   "contributors": [
@@ -11,6 +11,11 @@
       "name": "Paul Arndt",
       "email": "paul.arndt@student.hpi.de",
       "url": "https://github.com/Atyanar"
+    },
+    {
+      "name": "Adrian Jost",
+      "email": "adrian.jost@student.hpi.de",
+      "url": "https://github.com/adrianjost"
     }
   ],
   "private": true,
@@ -29,6 +34,7 @@
     "@uppy/core": "^0.27.0",
     "@uppy/react": "^0.27.1",
     "@uppy/tus": "^0.27.1",
+    "browser-media-mime-type": "^1.0.0",
     "bulma": "^0.7.1",
     "bulma-tooltip": "^2.0.2",
     "immutable": "^3.8.2",

--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,3 @@
-/*.documentViewer-wrapper {
-  background-color: #222;
-  color: white;
-  padding: 5px;
-  max-height: 100vh;
-  overflow: auto;
-}
-*/
-
 .plugin-wrapper {
   margin: 20px 0;
 }
@@ -24,29 +15,6 @@
   width: 100%;
   min-height: 30rem;
 }
-
-/*
-a.download {
-  background-color: grey;
-  border: none;
-  color: white;
-  padding: 15px 32px;
-  text-align: center;
-  text-decoration: none;
-  display: inline-block;
-  font-size: 16px;
-  cursor: pointer;
-  margin: 10px 0;
-}
-
-a.download:hover {
-  background-color: darkgrey;
-}
-
-a.download > i {
-  margin-right: 10px;
-}
-*/
 
 .embed-container {
   position: relative;

--- a/src/plugins/audio/index.js
+++ b/src/plugins/audio/index.js
@@ -1,0 +1,60 @@
+import React from "react";
+
+export default function Audio(options) {
+  return {
+    changes: {},
+    helpers: {},
+    components: { AudioNode },
+    plugins: [RenderAudioNode, { schema }],
+  };
+}
+
+const schema = {
+  blocks: {
+    audio: {
+      isVoid: true,
+    },
+  },
+};
+
+function AudioNode(props) {
+  const { src, mimeType, selected, ...attributes } = props;
+
+  return (
+    <div
+      className={`plugin-wrapper ${selected ? "selected" : ""}`}
+      {...attributes}
+    >
+      <audio
+        className="audio"
+        controls
+        preload="metadata"
+        style={{ width: "100%", minHeight: "54px" }}
+      >
+        <source src={src} type={mimeType} />
+        Your browser does not support the audio tag.
+      </audio>
+    </div>
+  );
+}
+
+const RenderAudioNode = {
+  renderNode(props) {
+    const { attributes, node, isFocused } = props;
+
+    if (node.type === "audio") {
+      const src = node.data.get("src");
+      const mimeType = node.data.get("mimeType");
+      if ((mimeType || "").includes("audio")) {
+        return (
+          <AudioNode
+            src={src}
+            mimeType={mimeType}
+            selected={isFocused}
+            {...attributes}
+          />
+        );
+      }
+    }
+  },
+};

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -11,6 +11,8 @@ import Image from "./image/index";
 // @ts-ignore:
 import MarkdownShortcuts from "./markdown-shortcuts/index";
 // @ts-ignore:
+import PasteURLHandler from "./paste-url-handler/index";
+// @ts-ignore:
 import PlusMenuPlugin from "./plus-menu/index";
 // @ts-ignore:
 import Section from "./section/index";
@@ -26,6 +28,7 @@ export const plugins = [
   ...Headlines().plugins,
   ...MarkdownShortcuts().plugins,
   ...Embed().plugins,
+  ...PasteURLHandler().plugins,
   ...CodeBlockPlugin().plugins,
   ...Image().plugins,
   ...Geogebra().plugins,

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,4 +1,6 @@
 // @ts-ignore:
+import Audio from "./audio/index";
+// @ts-ignore:
 import CodeBlockPlugin from "./code-block/index";
 // @ts-ignore:
 import Embed from "./embed/index";
@@ -20,6 +22,8 @@ import Section from "./section/index";
 import TextMenu from "./text-menu/index";
 // @ts-ignore:
 import Title from "./title/index";
+// @ts-ignore:
+import Video from "./video/index";
 
 export const plugins = [
   ...Title().plugins,
@@ -28,6 +32,8 @@ export const plugins = [
   ...Headlines().plugins,
   ...MarkdownShortcuts().plugins,
   ...Embed().plugins,
+  ...Video().plugins,
+  ...Audio().plugins,
   ...PasteURLHandler().plugins,
   ...CodeBlockPlugin().plugins,
   ...Image().plugins,

--- a/src/plugins/paste-url-handler/handlers/AudioHandler.js
+++ b/src/plugins/paste-url-handler/handlers/AudioHandler.js
@@ -1,5 +1,3 @@
-import React from "react";
-
 import mimeLookup from "browser-media-mime-type";
 
 export default function AudioHandler(options) {
@@ -10,20 +8,10 @@ export default function AudioHandler(options) {
       insertAudio,
     },
     helpers: {},
-    components: {
-      AudioNode,
-    },
-    plugins: [RenderAudioNode, { schema }],
+    components: {},
+    plugins: [],
   };
 }
-
-const schema = {
-  blocks: {
-    audio: {
-      isVoid: true,
-    },
-  },
-};
 
 const validate = url => {
   const fileExtension = url.substr(url.lastIndexOf(".") + 1);
@@ -44,45 +32,3 @@ function insertAudio(change, src, mimeType, target) {
     data: { src, mimeType },
   });
 }
-
-function AudioNode(props) {
-  const { src, mimeType, selected, ...attributes } = props;
-
-  return (
-    <div
-      className={`plugin-wrapper ${selected ? "selected" : ""}`}
-      {...attributes}
-    >
-      <audio
-        className="audio"
-        controls
-        preload="metadata"
-        style={{ width: "100%", minHeight: "54px" }}
-      >
-        <source src={src} type={mimeType} />
-        Your browser does not support the audio tag.
-      </audio>
-    </div>
-  );
-}
-
-const RenderAudioNode = {
-  renderNode(props) {
-    const { attributes, node, isFocused } = props;
-
-    if (node.type === "audio") {
-      const src = node.data.get("src");
-      const mimeType = node.data.get("mimeType");
-      if ((mimeType || "").includes("audio")) {
-        return (
-          <AudioNode
-            src={src}
-            mimeType={mimeType}
-            selected={isFocused}
-            {...attributes}
-          />
-        );
-      }
-    }
-  },
-};

--- a/src/plugins/paste-url-handler/handlers/AudioHandler.js
+++ b/src/plugins/paste-url-handler/handlers/AudioHandler.js
@@ -1,0 +1,88 @@
+import React from "react";
+
+import mimeLookup from "browser-media-mime-type";
+
+export default function AudioHandler(options) {
+  return {
+    validate,
+    dealWithIt,
+    changes: {
+      insertAudio,
+    },
+    helpers: {},
+    components: {
+      AudioNode,
+    },
+    plugins: [RenderAudioNode, { schema }],
+  };
+}
+
+const schema = {
+  blocks: {
+    audio: {
+      isVoid: true,
+    },
+  },
+};
+
+const validate = url => {
+  const fileExtension = url.substr(url.lastIndexOf(".") + 1);
+  const mimeType = mimeLookup(fileExtension);
+  return (mimeType || "").includes("audio");
+};
+
+const dealWithIt = (url, change) => {
+  const fileExtension = url.substr(url.lastIndexOf(".") + 1);
+  const mimeType = mimeLookup(fileExtension);
+  change.call(insertAudio, url, mimeType);
+  return true;
+};
+
+function insertAudio(change, src, mimeType, target) {
+  change.insertBlock({
+    type: "audio",
+    data: { src, mimeType },
+  });
+}
+
+function AudioNode(props) {
+  const { src, mimeType, selected, ...attributes } = props;
+
+  return (
+    <div
+      className={`plugin-wrapper ${selected ? "selected" : ""}`}
+      {...attributes}
+    >
+      <audio
+        className="audio"
+        controls
+        preload="metadata"
+        style={{ width: "100%", minHeight: "54px" }}
+      >
+        <source src={src} type={mimeType} />
+        Your browser does not support the audio tag.
+      </audio>
+    </div>
+  );
+}
+
+const RenderAudioNode = {
+  renderNode(props) {
+    const { attributes, node, isFocused } = props;
+
+    if (node.type === "audio") {
+      const src = node.data.get("src");
+      const mimeType = node.data.get("mimeType");
+      if ((mimeType || "").includes("audio")) {
+        return (
+          <AudioNode
+            src={src}
+            mimeType={mimeType}
+            selected={isFocused}
+            {...attributes}
+          />
+        );
+      }
+    }
+  },
+};

--- a/src/plugins/paste-url-handler/handlers/VideoHandler.js
+++ b/src/plugins/paste-url-handler/handlers/VideoHandler.js
@@ -1,8 +1,6 @@
-import React from "react";
-
 import mimeLookup from "browser-media-mime-type";
 
-export default function YoutubeHandler(options) {
+export default function VideoHandler(options) {
   return {
     validate,
     dealWithIt,
@@ -10,20 +8,10 @@ export default function YoutubeHandler(options) {
       insertVideo,
     },
     helpers: {},
-    components: {
-      VideoNode,
-    },
-    plugins: [RenderVideoNode, { schema }],
+    components: {},
+    plugins: [],
   };
 }
-
-const schema = {
-  blocks: {
-    video: {
-      isVoid: true,
-    },
-  },
-};
 
 const validate = url => {
   const fileExtension = url.substr(url.lastIndexOf(".") + 1);
@@ -44,40 +32,3 @@ function insertVideo(change, src, mimeType) {
     data: { src, mimeType },
   });
 }
-
-function VideoNode(props) {
-  const { src, mimeType, selected, ...attributes } = props;
-
-  return (
-    <div
-      className={`plugin-wrapper ${selected ? "selected" : ""}`}
-      {...attributes}
-    >
-      <video className="video" controls preload="metadata">
-        <source src={src} type={mimeType} />
-        Your browser does not support the video tag.
-      </video>
-    </div>
-  );
-}
-
-const RenderVideoNode = {
-  renderNode(props) {
-    const { attributes, node, isFocused } = props;
-
-    if (node.type === "video") {
-      const src = node.data.get("src");
-      const mimeType = node.data.get("mimeType");
-      if ((mimeType || "").includes("video")) {
-        return (
-          <VideoNode
-            src={src}
-            mimeType={mimeType}
-            selected={isFocused}
-            {...attributes}
-          />
-        );
-      }
-    }
-  },
-};

--- a/src/plugins/paste-url-handler/handlers/VideoHandler.js
+++ b/src/plugins/paste-url-handler/handlers/VideoHandler.js
@@ -1,0 +1,83 @@
+import React from "react";
+
+import mimeLookup from "browser-media-mime-type";
+
+export default function YoutubeHandler(options) {
+  return {
+    validate,
+    dealWithIt,
+    changes: {
+      insertVideo,
+    },
+    helpers: {},
+    components: {
+      VideoNode,
+    },
+    plugins: [RenderVideoNode, { schema }],
+  };
+}
+
+const schema = {
+  blocks: {
+    video: {
+      isVoid: true,
+    },
+  },
+};
+
+const validate = url => {
+  const fileExtension = url.substr(url.lastIndexOf(".") + 1);
+  const mimeType = mimeLookup(fileExtension);
+  return (mimeType || "").includes("video");
+};
+
+const dealWithIt = (url, change) => {
+  const fileExtension = url.substr(url.lastIndexOf(".") + 1);
+  const mimeType = mimeLookup(fileExtension);
+  change.call(insertVideo, url, mimeType);
+  return true;
+};
+
+function insertVideo(change, src, mimeType) {
+  change.insertBlock({
+    type: "video",
+    data: { src, mimeType },
+  });
+}
+
+function VideoNode(props) {
+  const { src, mimeType, selected, ...attributes } = props;
+
+  return (
+    <div
+      className={`plugin-wrapper ${selected ? "selected" : ""}`}
+      {...attributes}
+    >
+      <video className="video" controls preload="metadata">
+        <source src={src} type={mimeType} />
+        Your browser does not support the video tag.
+      </video>
+    </div>
+  );
+}
+
+const RenderVideoNode = {
+  renderNode(props) {
+    const { attributes, node, isFocused } = props;
+
+    if (node.type === "video") {
+      const src = node.data.get("src");
+      const mimeType = node.data.get("mimeType");
+      if ((mimeType || "").includes("video")) {
+        return (
+          <VideoNode
+            src={src}
+            mimeType={mimeType}
+            selected={isFocused}
+            {...attributes}
+          />
+        );
+      }
+    }
+  },
+};

--- a/src/plugins/paste-url-handler/handlers/VimeoHandler.js
+++ b/src/plugins/paste-url-handler/handlers/VimeoHandler.js
@@ -1,0 +1,36 @@
+export default function VimeoHandler(options) {
+  return {
+    validate,
+    dealWithIt,
+    changes: {
+      insertYoutubeVideo,
+    },
+    helpers: {},
+    components: {},
+    plugins: [],
+  };
+}
+
+//eslint-disable-next-line
+const _regex = /vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^\/]*)\/videos\/|)(\d+)(?:|\/\?)/i;
+
+const validate = url => {
+  return !!_regex.exec(url);
+};
+
+const dealWithIt = (url, change) => {
+  const videoId = _regex.exec(url)[2];
+  change.call(insertYoutubeVideo, videoId);
+  return true;
+};
+
+function insertYoutubeVideo(change, videoId) {
+  change.insertBlock({
+    type: "embed",
+    isVoid: true,
+    data: {
+      provider: "vimeo",
+      url: `https://player.vimeo.com/video/${videoId}`,
+    },
+  });
+}

--- a/src/plugins/paste-url-handler/handlers/YoutubeHandler.js
+++ b/src/plugins/paste-url-handler/handlers/YoutubeHandler.js
@@ -1,0 +1,35 @@
+export default function YoutubeHandler(options) {
+  return {
+    validate,
+    dealWithIt,
+    changes: {
+      insertYoutubeVideo,
+    },
+    helpers: {},
+    components: {},
+    plugins: [],
+  };
+}
+
+const _regex = /youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-_]*)/i;
+
+const validate = url => {
+  return !!_regex.exec(url);
+};
+
+const dealWithIt = (url, change) => {
+  const videoId = _regex.exec(url)[1];
+  change.call(insertYoutubeVideo, videoId);
+  return true;
+};
+
+function insertYoutubeVideo(change, videoId) {
+  change.insertBlock({
+    type: "embed",
+    isVoid: true,
+    data: {
+      provider: "youtube",
+      url: `https://www.youtube-nocookie.com/embed/${videoId}`,
+    },
+  });
+}

--- a/src/plugins/paste-url-handler/index.js
+++ b/src/plugins/paste-url-handler/index.js
@@ -1,0 +1,53 @@
+import { getEventTransfer } from "slate-react";
+import isUrl from "is-url";
+
+import YoutubeHandler from "./handlers/YoutubeHandler";
+import VimeoHandler from "./handlers/VimeoHandler";
+import VideoHandler from "./handlers/VideoHandler";
+import AudioHandler from "./handlers/AudioHandler";
+
+export default function PasteURLHandler(options) {
+  return {
+    changes: {},
+    helpers: {},
+    components: {},
+    plugins: [
+      HandlePaste,
+      ...YoutubeHandler().plugins,
+      ...VimeoHandler().plugins,
+      ...VideoHandler().plugins,
+      ...AudioHandler().plugins,
+    ],
+  };
+}
+
+const HandlePaste = {
+  onPaste(event, change, editor) {
+    const transfer = getEventTransfer(event);
+    const { type, text } = transfer;
+
+    if (type === "text") {
+      if (!isUrl(text)) {
+        return;
+      }
+
+      if (YoutubeHandler().validate(text)) {
+        return YoutubeHandler().dealWithIt(text, change);
+      }
+
+      if (VimeoHandler().validate(text)) {
+        return VimeoHandler().dealWithIt(text, change);
+      }
+
+      if (VideoHandler().validate(text)) {
+        return VideoHandler().dealWithIt(text, change);
+      }
+
+      if (AudioHandler().validate(text)) {
+        return AudioHandler().dealWithIt(text, change);
+      }
+
+      return;
+    }
+  },
+};

--- a/src/plugins/video/index.js
+++ b/src/plugins/video/index.js
@@ -1,0 +1,55 @@
+import React from "react";
+
+export default function Video(options) {
+  return {
+    changes: {},
+    helpers: {},
+    components: { VideoNode },
+    plugins: [RenderVideoNode, { schema }],
+  };
+}
+
+const schema = {
+  blocks: {
+    video: {
+      isVoid: true,
+    },
+  },
+};
+
+function VideoNode(props) {
+  const { src, mimeType, selected, ...attributes } = props;
+
+  return (
+    <div
+      className={`plugin-wrapper ${selected ? "selected" : ""}`}
+      {...attributes}
+    >
+      <video className="video" controls preload="metadata">
+        <source src={src} type={mimeType} />
+        Your browser does not support the video tag.
+      </video>
+    </div>
+  );
+}
+
+const RenderVideoNode = {
+  renderNode(props) {
+    const { attributes, node, isFocused } = props;
+
+    if (node.type === "video") {
+      const src = node.data.get("src");
+      const mimeType = node.data.get("mimeType");
+      if ((mimeType || "").includes("video")) {
+        return (
+          <VideoNode
+            src={src}
+            mimeType={mimeType}
+            selected={isFocused}
+            {...attributes}
+          />
+        );
+      }
+    }
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2664,6 +2664,11 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
+browser-media-mime-type@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browser-media-mime-type/-/browser-media-mime-type-1.0.0.tgz#a1534a8ad938f0bcf4b642f540fa35605653d0e9"
+  integrity sha1-oVNKitk48Lz0tkL1QPo1YFZT0Ok=
+
 browser-process-hrtime@^0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"


### PR DESCRIPTION
This reintroduces the `plugins/paste-url-handler` (formerly known as `url-handler`.
It now reflects the recent changes going from `plugins/iframe` to `plugins/embed`.

This also introduces support for video and audio files supplied as links, thanks to @adrianjost.

Closes #102 , closes #103.