### PR TITLE
Update Typescript to 3.2.1 (#118)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/.vscode

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-react": "^3.6.0",
-    "typescript": "^3.1.6"
+    "typescript": "^3.2.1"
   },
   "husky": {
     "hooks": {

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -79,6 +79,7 @@ class Editor extends PureComponent<IEditorProps, IEditorState> {
               value={this.state.value}
               onChange={this.onChange}
               className="slate-editor"
+              // @ts-ignore: slate/types 43 is not current... - this works perfectly fine
               schema={schema}
               readOnly={!this.props.isEditable}
             />

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,6 @@
 import { Block, Editor } from "slate";
 
-export default {
+const schema: object = {
   document: {
     nodes: [
       { match: [{ type: "title" }], min: 1, max: 1 },
@@ -55,11 +55,11 @@ export default {
     code: {
       marks: [],
     },
-    embed: {
-      marks: [],
-    },
+    embed: { marks: [] },
     audio: {
       isVoid: true,
     },
   },
 };
+
+export default schema;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13206,10 +13206,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION

## Proposed Changes
  - Updates Typescript to 3.2.1
 

Fixes #118 (it wasn't really broken in the first place, since the typescript version marked in the repo was 3.1.6, but a lot of people seem to just be using latest typescript and this should fix the issue for them)