### PR TITLE
additional helpers for plugins inside row

### DIFF
--- a/src/plugins/rows/Editor/render.js
+++ b/src/plugins/rows/Editor/render.js
@@ -11,6 +11,13 @@ export default function({
         renderIntoExtendedSettings,
         PrimarySettingsWrapper,
         insert: options => rows.insert(index + 1, options),
+        replace: options => {
+            rows.remove(index)
+            rows.insert(index, options)
+        },
+        remove: () => {
+            rows.remove(index)
+        },
         mergeWithPrevious: merge => {
             if (index - 1 < 0) return
             const previous = getDocument(store.state, rows()[index - 1].id)


### PR DESCRIPTION

## Proposed Changes
  Pass `remove` and `replace` helpers to plugins inside of rows plugin. These helpers are already used in `@edtr-io/plugin-text` v0.5.0 to ...
  - leave nested plugins (e.g. inside spoiler) by pressing enter twice
  - wrap/unwrap texts with blockquotes plugins using the quote button in the text controls